### PR TITLE
Update servers.json: add mcp-timeplus

### DIFF
--- a/public/servers.json
+++ b/public/servers.json
@@ -174,6 +174,19 @@
     "homepage": "https://github.com/modelcontextprotocol/servers"
   },
   {
+    "key": "Timeplus",
+    "command": "uvx",
+    "description": "MCP Server for Timeplus, a SQL database to process millions of rows per second from Kafka, Pulsar, or ClickHouse.",
+    "args": ["mcp-timeplus"],
+    "env": {
+      "TIMEPLUS_HOST": "{{host@string::database host, e.g. localhost}}",
+      "TIMEPLUS_PORT": "{{port@number::database port, e.g. 8123}}",
+      "TIMEPLUS_USER": "{{user@string::database user, e.g. default}}",
+      "TIMEPLUS_PASSWORD": "{{pass@string::database password, can be empty}}"
+    },
+    "homepage": "https://github.com/jovezhong/mcp-timeplus"
+  },
+  {
     "key": "Web",
     "command": "uvx",
     "description": "A Model Context Protocol server that provides web content fetching capabilities",


### PR DESCRIPTION
Greetings,

I am adding the mcp-timeplus, to list database/table and run SQL for Timeplus. It works with https://github.com/timeplus-io/proton and our enterprise edition.