### PR TITLE
Fix and optimize the search experience

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,16 +4,16 @@ import HeroText from '@/components/hero-text'
 import {RetroGrid} from '@/components/ui/retro-grid'
 import SearchInput from '@/components/search-input'
 import allServers from '@/public/servers.json'
-import {useState, useMemo} from 'react'
+import {useState, useMemo, useCallback} from 'react'
 import ServerDialog from '@/components/server-dialog'
 
 export default function Home() {
     const [filter, setFilter] = useState<string[]>([])
     const [open, setOpen] = useState(false)
     const [server, setServer] = useState(null)
-    const onSearch = (words: string[]) => {
-        setFilter(words)
-    }
+    const onSearch = useCallback((words: string[]) => {
+      setFilter(words)
+    }, [])
     const highlightText = (text: string) => {
         let result = text
         filter.forEach((word) => {

--- a/components/search-input.tsx
+++ b/components/search-input.tsx
@@ -27,7 +27,7 @@ export default function SearchInput(options: {
     )
 
     useEffect(() => {
-        debouncedSearch(searchTerm)
+        searchTerm && debouncedSearch(searchTerm)
         return () => debouncedSearch.cancel()
     }, [searchTerm, debouncedSearch])
 

--- a/components/search-input.tsx
+++ b/components/search-input.tsx
@@ -14,15 +14,22 @@ export default function SearchInput(options: {
 }) {
     const [searchTerm, setSearchTerm] = useState('')
 
+    const clearSearch = () => {
+        setSearchTerm('')
+        debouncedSearch.cancel()
+        options.onSearch([])
+    }
+
     const onInput = (evt: FormEvent<HTMLInputElement>) => {
-        setSearchTerm((evt.target as HTMLInputElement).value || '')
+        const value = (evt.target as HTMLInputElement).value
+        value ? setSearchTerm(value) : clearSearch()
     }
 
     const debouncedSearch = useCallback(
         debounce((value: string) => {
             const words = value.split(/\s+/g).filter(Boolean)
             options.onSearch(words)
-        }, 500),
+        }, 300),
         [options.onSearch]
     )
 
@@ -39,13 +46,7 @@ export default function SearchInput(options: {
                     className="size-4 text-muted-foreground"
                 />
                 <SearchFieldInput placeholder="Search..." onChange={onInput} />
-                <SearchFieldClear
-                    onPress={() => {
-                        setSearchTerm('')
-                        debouncedSearch.cancel()
-                        options.onSearch([])
-                    }}
-                >
+                <SearchFieldClear onPress={clearSearch}>
                     <XIcon aria-hidden className="size-4" />
                 </SearchFieldClear>
             </FieldGroup>

--- a/components/ui/searchfield.tsx
+++ b/components/ui/searchfield.tsx
@@ -36,7 +36,7 @@ function SearchFieldInput({ className, ...props }: AriaInputProps) {
     <AriaInput
       className={composeRenderProps(className, (className) =>
         cn(
-          "min-w-0 flex-1 bg-background px-2 py-1.5 outline outline-0 placeholder:text-muted-foreground [&::-webkit-search-cancel-button]:hidden",
+          "min-w-0 flex-1 bg-background px-2 py-1.5 outline outline-0 focus:outline-none text-base placeholder:text-muted-foreground [&::-webkit-search-cancel-button]:hidden",
           className
         )
       )}


### PR DESCRIPTION
1. Page re-rendering causes the system's Command+F search to fail.
2. After using the keyboard clear key to empty the search component, the list does not display correctly.
3. When using search on mobile, the page zooms in and needs to be manually reduced.