### PR TITLE
Add BuyWhere MCP server

### DIFF
--- a/public/servers.json
+++ b/public/servers.json
@@ -119,6 +119,17 @@
     "homepage": "https://browsermcp.io"
   },
   {
+    "name": "BuyWhere",
+    "key": "BuyWhere",
+    "command": "npx",
+    "description": "BuyWhere MCP server — product catalog tools for Claude Desktop, Cursor, and other MCP-compatible agents. Search and compare products across US, Singapore, and SEA markets.",
+    "args": ["-y", "buywhere-mcp"],
+    "env": {
+      "BUYWHERE_API_KEY": "{{apiKey@string::Get your free API key from https://buywhere.ai}}"
+    },
+    "homepage": "https://github.com/BuyWhere/buywhere-mcp"
+  },
+  {
     "name": "Cribl MCP",
     "key": "CriblMcp",
     "description": "MCP server for managing Cribl configuration and resources, including worker groups, pipelines, routes and sources.",


### PR DESCRIPTION
Add BuyWhere MCP server entry to public/servers.json — a product catalog API for AI agents.

BuyWhere gives AI agents real-time access to Southeast Asia's largest product catalog. Search 1.5M+ products across Shopee, Lazada, Amazon, Walmart, and 20+ e-commerce platforms via a single MCP endpoint.

- Inserts alphabetically between Browsermcp and Cribl MCP
- STDIO: `npx -y buywhere-mcp`
- Requires BUYWHERE_API_KEY env var (free from https://buywhere.ai)
- Homepage: https://github.com/BuyWhere/buywhere-mcp