### PR TITLE
Add Xquik MCP server

### DIFF
--- a/public/servers.json
+++ b/public/servers.json
@@ -122,7 +122,7 @@
     "name": "BuyWhere",
     "key": "BuyWhere",
     "command": "npx",
-    "description": "BuyWhere MCP server — product catalog tools for Claude Desktop, Cursor, and other MCP-compatible agents. Search and compare products across US, Singapore, and SEA markets.",
+    "description": "BuyWhere MCP server - product catalog tools for Claude Desktop, Cursor, and other MCP-compatible agents. Search and compare products across US, Singapore, and SEA markets.",
     "args": ["-y", "buywhere-mcp"],
     "env": {
       "BUYWHERE_API_KEY": "{{apiKey@string::Get your free API key from https://buywhere.ai}}"
@@ -580,6 +580,25 @@
     "description": "A Model Context Protocol server that provides web content fetching capabilities",
     "args": ["mcp-server-fetch"],
     "homepage": "https://pypi.org/project/mcp-server-fetch/"
+  },
+  {
+    "name": "Xquik",
+    "key": "Xquik",
+    "command": "npx",
+    "description": "Remote MCP server for X data workflows with REST API coverage, extraction tools, webhooks, and account actions.",
+    "args": [
+      "-y",
+      "mcp-remote@0.1.38",
+      "https://xquik.com/mcp",
+      "--transport",
+      "http-only",
+      "--header",
+      "Authorization:${XQUIK_AUTH_HEADER}"
+    ],
+    "env": {
+      "XQUIK_AUTH_HEADER": "Bearer {{apiKey@string::Xquik API key from https://dashboard.xquik.com/en/account}}"
+    },
+    "homepage": "https://docs.xquik.com/mcp/overview"
   },
   {
     "name": "Zerolab Email",


### PR DESCRIPTION
## Summary
- Add Xquik as a remote MCP server using `mcp-remote@0.1.38`.
- Include an API-key header placeholder and docs homepage.
- Normalize one existing dash in the BuyWhere description.

## Validation
- `jq empty public/servers.json`
- Duplicate gate: no existing Xquik PRs or issues in `nanbingxyz/mcpsvr`
- `npm view mcp-remote@0.1.38 version`
- `https://docs.xquik.com/mcp/overview` returns 200
- `https://xquik.com/mcp` returns the expected unauthenticated 401 with bearer metadata
