### PR TITLE
Add OptionsAhoy MCP server (equity-comp tax/trade optimizer)

### DIFF
--- a/public/servers.json
+++ b/public/servers.json
@@ -663,5 +663,20 @@
       "{{vision@boolean::(default: false) Enable vision mode (screenshots instead of accessibility snapshots)}}"
     ],
     "homepage": "https://github.com/microsoft/playwright-mcp"
+  },
+  {
+    "name": "OptionsAhoy",
+    "key": "OptionsAhoy",
+    "description": "Equity-compensation tax/trade optimizer: ISO/AMT exercise scheduling, NSO, RSU sell-vs-hold, QSBS qualification, single-stock concentration, protective-put/collar hedging, and multi-year equity-funding plans. Full federal tax code plus all 50 states and DC.",
+    "command": "npx",
+    "args": [
+      "-y",
+      "mcp-remote",
+      "https://optionsahoy.com/mcp"
+    ],
+    "env": {
+      "npm_config_yes": "true"
+    },
+    "homepage": "https://optionsahoy.com/for-agents"
   }
 ]


### PR DESCRIPTION
Adds **OptionsAhoy**, a remote MCP server for equity-compensation tax and trade planning: ISO/AMT exercise scheduling, NSO, RSU sell-vs-hold, Section 1202 QSBS qualification, single-stock concentration, protective-put/collar hedging, and multi-year equity-funding plans, computed against the full federal tax code plus all 50 states and DC.

- Remote streamable-HTTP endpoint, no auth, bridged via `mcp-remote` (same pattern as the existing "Rube" entry).
- Endpoint: https://optionsahoy.com/mcp (verified live: responds to MCP `initialize`, 7 tools).
- Homepage / agent docs: https://optionsahoy.com/for-agents
- Source: https://github.com/AlvisoOculus/optionsahoy-mcp

Single entry appended to `public/servers.json`; JSON validated.
