### PR TITLE
Add hushvert MCP server

### DIFF
--- a/public/servers.json
+++ b/public/servers.json
@@ -678,5 +678,19 @@
       "npm_config_yes": "true"
     },
     "homepage": "https://optionsahoy.com/for-agents"
+  },
+  {
+    "name": "hushvert",
+    "key": "Hushvert",
+    "description": "File conversion for AI agents over the hushvert hosted API: office docs to PDF, PDF to Word, document interchange (Markdown/HTML/EPUB/LaTeX), and audio/video transcodes.",
+    "command": "npx",
+    "args": [
+      "-y",
+      "@hushvert/mcp"
+    ],
+    "env": {
+      "HUSHVERT_API_KEY": "{{hushvertKey@string::Get a developer key at https://hushvert.com/developers/keys}}"
+    },
+    "homepage": "https://github.com/hushvert/mcp"
   }
 ]


### PR DESCRIPTION
Adds the `hushvert` MCP server to `public/servers.json`.

hushvert is a file-conversion server for AI agents over the hushvert hosted API: office documents to PDF, PDF to Word, document interchange (Markdown/HTML/EPUB/LaTeX via pandoc), and audio/video transcodes. It installs via `npx -y @hushvert/mcp` (stdio) and reads a `HUSHVERT_API_KEY` from the environment, following the same shape as the existing key-based `npx` entries (Firecrawl, AMap).

- npm: https://www.npmjs.com/package/@hushvert/mcp
- Repo: https://github.com/hushvert/mcp
- Get a key: https://hushvert.com/developers/keys

The new entry uses the documented `{{param@string::...}}` placeholder for the API key, and `servers.json` still validates as JSON.