### PR TITLE
Add Bargo Congress Trades MCP server

### DIFF
--- a/public/servers.json
+++ b/public/servers.json
@@ -711,5 +711,24 @@
       "HUSHVERT_API_KEY": "{{hushvertKey@string::Get a developer key at https://hushvert.com/developers/keys}}"
     },
     "homepage": "https://github.com/hushvert/mcp"
+  },
+  {
+    "name": "Bargo Congress Trades",
+    "key": "BargoCongressTrades",
+    "description": "Read-only access to normalized U.S. House and Senate STOCK Act disclosures, with filters for ticker, member, chamber, transaction type, and date.",
+    "command": "npx",
+    "args": [
+      "-y",
+      "mcp-remote@0.1.38",
+      "https://www.bargo.ai/free-apis/congress/mcp",
+      "--transport",
+      "http-only",
+      "--header",
+      "Authorization:${BARGO_CONGRESS_AUTH_HEADER}"
+    ],
+    "env": {
+      "BARGO_CONGRESS_AUTH_HEADER": "Bearer {{apiKey@string::Free Bargo API key from https://www.bargo.ai/free-apis/dash}}"
+    },
+    "homepage": "https://www.bargo.ai/free-apis/congress"
   }
 ]


### PR DESCRIPTION
Hi, I'm Ankur, the developer behind Bargo. I'd like to add our Congress Trades MCP server to MCPSvr.

It gives MCP clients read-only access to normalized U.S. House and Senate STOCK Act disclosures. The tools support trade lookups by ticker, member, chamber, transaction type, and date, along with member histories and aggregate statistics.

I followed the existing remote-server pattern in this registry and configured it through `mcp-remote@0.1.38` using Streamable HTTP. Users can generate a free Bargo API key and pass it as a Bearer token.

- MCP endpoint: https://www.bargo.ai/free-apis/congress/mcp
- Documentation: https://www.bargo.ai/free-apis/congress
- Free API key: https://www.bargo.ai/free-apis/dash

I checked that the registry JSON parses, the key is unique, the endpoint completes an MCP initialization handshake, and the project still passes its production build.